### PR TITLE
add option to use downloadable twitter emoji

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/CustomTypefaceSpan.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/CustomTypefaceSpan.java
@@ -1,0 +1,42 @@
+//TODO: put in right package
+package com.moez.QKSMS;
+
+import android.graphics.Paint;
+import android.graphics.Typeface;
+import android.text.TextPaint;
+import android.text.style.MetricAffectingSpan;
+
+public class CustomTypefaceSpan extends MetricAffectingSpan {
+    private final Typeface typeface;
+
+    public CustomTypefaceSpan(final Typeface typeface) {
+        this.typeface = typeface;
+    }
+
+    @Override
+    public void updateDrawState(final TextPaint drawState) {
+        apply(drawState);
+    }
+
+    @Override
+    public void updateMeasureState(final TextPaint paint) {
+        apply(paint);
+    }
+
+    private void apply(final Paint paint) {
+        final Typeface oldTypeface = paint.getTypeface();
+        final int oldStyle = oldTypeface != null ? oldTypeface.getStyle() : 0;
+        final int fakeStyle = oldStyle & ~typeface.getStyle();
+
+        if ((fakeStyle & Typeface.BOLD) != 0) {
+            paint.setFakeBoldText(true);
+        }
+
+        if ((fakeStyle & Typeface.ITALIC) != 0) {
+            paint.setTextSkewX(-0.25f);
+        }
+
+        paint.setTypeface(typeface);
+    }
+}
+

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/settings/SettingsFragment.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/settings/SettingsFragment.java
@@ -396,7 +396,7 @@ public class SettingsFragment extends PreferenceFragment implements
     }
 
     @Override
-    public boolean onPreferenceChange(Preference preference, Object newValue) {
+    public boolean onPreferenceChange(final Preference preference, Object newValue) {
 
         String key = preference.getKey();
 
@@ -457,7 +457,7 @@ public class SettingsFragment extends PreferenceFragment implements
                 new AlertDialog.Builder(mContext)
                         .setTitle(R.string.download_emoji_title)
                         .setMessage(R.string.download_emoji_message)
-                        .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                        .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
                                 String url = "https://dl.dropboxusercontent.com/u/1181440/TwitterEmoji.ttf"; //TODO: put this file on a better server
@@ -473,7 +473,12 @@ public class SettingsFragment extends PreferenceFragment implements
                                 manager.enqueue(request);
                             }
                         })
-                        .setNegativeButton("No", null) //TODO: handle this better
+                        .setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((CheckBoxPreference)preference).setChecked(false);
+                            }
+                        })
                         .show();
             }
         } else if (key.equals(QUICKCOMPOSE)) {

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/view/QKTextView.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/view/QKTextView.java
@@ -2,12 +2,17 @@ package com.moez.QKSMS.ui.view;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.graphics.Typeface;
 import android.os.Build;
 import android.text.Layout;
 import android.text.SpannableStringBuilder;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.util.TypedValue;
 import android.widget.TextView;
+
+import com.moez.QKSMS.CustomTypefaceSpan;
+import com.moez.QKSMS.common.utils.EmojiUtils;
 import com.moez.QKSMS.interfaces.LiveView;
 import com.moez.QKSMS.common.FontManager;
 import com.moez.QKSMS.common.LiveViewManager;
@@ -17,12 +22,15 @@ import com.moez.QKSMS.ui.MainActivity;
 import com.moez.QKSMS.ui.ThemeManager;
 import com.moez.QKSMS.ui.settings.SettingsFragment;
 
+import java.io.File;
+
 public class QKTextView extends TextView implements LiveView {
     private final String TAG = "QKTextView";
 
     private Context mContext;
     private int mType = FontManager.TEXT_TYPE_PRIMARY;
     private boolean mOnColorBackground = false;
+    private Typeface mEmojiFont;
 
     public QKTextView(Context context) {
         super(context);
@@ -133,6 +141,31 @@ public class QKTextView extends TextView implements LiveView {
     public void setText(CharSequence text, BufferType type) {
 
         SharedPreferences prefs = MainActivity.getPrefs(getContext());
+
+        // TODO: Optimize code if possible
+        if (prefs.getBoolean(SettingsFragment.ALTERNATE_EMOJI, false)) {
+            if (mEmojiFont == null && (new File(getContext().getExternalFilesDir("emojiFont"), "TwitterEmoji.ttf")).exists()) {
+                mEmojiFont = Typeface.createFromFile(new File(getContext().getExternalFilesDir("emojiFont"), "TwitterEmoji.ttf"));
+            }
+
+            if (mEmojiFont != null) {
+                SpannableStringBuilder emojiBuilder = new SpannableStringBuilder(text);
+                for (int i = 0; i < text.length(); i++) {
+                    CustomTypefaceSpan cts = new CustomTypefaceSpan(mEmojiFont);
+
+                    // For 8-bit emoji
+                    if (text.length() > i && EmojiUtils.isOnlyEmoji(text.subSequence(i, i + 1)) && !text.subSequence(i, i + 1).equals(" ")) {
+                        emojiBuilder.setSpan(cts, i, i + 1, 0);
+                    }
+
+                    // For 16-bit emoji
+                    if (text.length() >= i + 2 && EmojiUtils.isOnlyEmoji(text.subSequence(i, i + 2))) {
+                        emojiBuilder.setSpan(cts, i, i + 2, 0);
+                    }
+                }
+                text = emojiBuilder;
+            }
+        }
 
         if (mType == FontManager.TEXT_TYPE_DIALOG_BUTTON) {
             text = text.toString().toUpperCase();

--- a/QKSMS/src/main/res/values/strings.xml
+++ b/QKSMS/src/main/res/values/strings.xml
@@ -149,6 +149,8 @@
     <string name="pref_font_family">Font family</string>
     <string name="pref_font_size">Font size</string>
     <string name="pref_font_weight">Font weight</string>
+    <string name="pref_alternate_emoji">Use alternative emoji</string>
+    <string name="pref_alternate_emoji_summary">Use alternative emoji images in messages</string>
     <string name="pref_message_count">Message count</string>
     <string name="pref_message_count_summary">Show the number of messages for each conversation</string>
     <string name="pref_sliding_tab">Sliding panel tab</string>
@@ -713,6 +715,10 @@
     <string name="date_yesterday">Yesterday</string>
     <string name="date_just_now">Just now</string>
     <string name="compose_loading_attachment">Loading attachment</string>
+    <string name="download_emoji_message">Are you sure you want to download alternate emoji?</string>
+    <string name="download_emoji_title">Download Emoji</string>
+    <string name="download_emoji_notification_description">Twitter emoji for QKSMS</string>
+    <string name="download_emoji_notification_title">Downloading emoji</string>
 
     <string-array name="resend_menu">
         <item>Resend</item>

--- a/QKSMS/src/main/res/xml/settings_appearance.xml
+++ b/QKSMS/src/main/res/xml/settings_appearance.xml
@@ -91,6 +91,13 @@
             android:key="pref_key_font_weight"
             android:layout="@layout/list_item_preference"
             android:title="@string/pref_font_weight" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_key_alternate_emoji"
+            android:layout="@layout/list_item_preference"
+            android:title="@string/pref_alternate_emoji"
+            android:summary="@string/pref_alternate_emoji_summary"
+            android:widgetLayout="@layout/view_checkbox" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
This adds an option to use the twitter emoji as an alternative for the standard emoji provided by Android.
This version is unfinished (lacks the different emoji on input fields) and probably isn't the most efficient/the best way to do it, so maybe someone more skilled than me should take a look at this!
The emoji are downloaded on request.