### PR TITLE
Fix for qklabs/qksms#99

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/common/formatter/Formatter.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/formatter/Formatter.java
@@ -1,0 +1,5 @@
+package com.moez.QKSMS.common.formatter;
+
+public interface Formatter {
+    String format(String text);
+}

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/formatter/FormatterFactory.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/formatter/FormatterFactory.java
@@ -1,0 +1,12 @@
+package com.moez.QKSMS.common.formatter;
+
+public class FormatterFactory {
+    private static final Formatter[] FORMATTERS = {new NumberToContactFormatter()};
+
+    public static String format(String text) {
+        for (Formatter formatter : FORMATTERS) {
+            text = formatter.format(text);
+        }
+        return text;
+    }
+}

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/formatter/NumberToContactFormatter.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/formatter/NumberToContactFormatter.java
@@ -1,0 +1,43 @@
+package com.moez.QKSMS.common.formatter;
+
+import android.content.Context;
+import android.telephony.TelephonyManager;
+
+import com.google.i18n.phonenumbers.PhoneNumberMatch;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat;
+import com.moez.QKSMS.QKSMSAppBase;
+import com.moez.QKSMS.data.Contact;
+
+public class NumberToContactFormatter implements Formatter {
+    String mCountryIso;
+
+    @Override
+    public String format(String text) {
+        PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
+        Iterable<PhoneNumberMatch> matches = phoneNumberUtil.findNumbers(text, getCurrentCountryIso());
+        for (PhoneNumberMatch match : matches) {
+            Contact contact = Contact.get(match.rawString(), true);
+            if (contact.isNamed()) {
+                String nameAndNumber = phoneNumberUtil.format(match.number(), PhoneNumberFormat.NATIONAL)
+                        + " (" + contact.getName() + ")";
+                text = text.replace(match.rawString(), nameAndNumber);
+            } // If the contact doesn't exist yet, leave the number as-is
+        }
+        return text;
+    }
+
+    public String getCurrentCountryIso() {
+        if (mCountryIso == null) {
+            TelephonyManager tm = (TelephonyManager) QKSMSAppBase.getApplication().getSystemService(Context.TELEPHONY_SERVICE);
+            mCountryIso = tm.getNetworkCountryIso();
+            // Just in case the TelephonyManager method failed, fallback to US
+            if (mCountryIso == null) {
+                mCountryIso = "US";
+            }
+            mCountryIso = mCountryIso.toUpperCase();
+        }
+        return mCountryIso;
+    }
+
+}

--- a/QKSMS/src/main/java/com/moez/QKSMS/data/Contact.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/data/Contact.java
@@ -260,6 +260,10 @@ public class Contact {
         }
     }
 
+    public synchronized boolean isNamed() {
+        return !TextUtils.isEmpty(mName);
+    }
+
     public synchronized String getNameAndNumber() {
         return mNameAndNumber;
     }

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/messagelist/MessageItem.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/messagelist/MessageItem.java
@@ -39,6 +39,7 @@ import com.google.android.mms.pdu_alt.RetrieveConf;
 import com.google.android.mms.pdu_alt.SendReq;
 import com.moez.QKSMS.QKSMSApp;
 import com.moez.QKSMS.R;
+import com.moez.QKSMS.common.formatter.FormatterFactory;
 import com.moez.QKSMS.data.Contact;
 import com.moez.QKSMS.model.SlideModel;
 import com.moez.QKSMS.model.SlideshowModel;
@@ -152,6 +153,7 @@ public class MessageItem {
                 mContact = Contact.get(mAddress, canBlock).getName();
             }
             mBody = cursor.getString(columnsMap.mColumnSmsBody);
+            mBody = FormatterFactory.format(mBody);
 
             // Unless the message is currently in the progress of being sent, it gets a time stamp.
             if (!isOutgoingMessage()) {


### PR DESCRIPTION
This is some work in progress for the phone number to contact enhancement in the SMS view qklabs/qksms#99

Before (on AOSP SMS):
<img src="https://cloud.githubusercontent.com/assets/8037169/9821425/8805ef4c-58ba-11e5-9dfd-99baeb32fb44.png" width="250">

After: 
<img src="https://cloud.githubusercontent.com/assets/8037169/9821429/8bb82c90-58ba-11e5-8b66-79c9f0f7765d.png" width="250">


I'm open to any suggestions for the outputted format... We might just put the contact name with an onClickListener and a link style, or something totally different maybe
