### PR TITLE
fix potential wakelock

### DIFF
--- a/QKSMS/src/main/java/com/mariussoft/endlessjabber/sdk/EndlessJabberWakefulService.java
+++ b/QKSMS/src/main/java/com/mariussoft/endlessjabber/sdk/EndlessJabberWakefulService.java
@@ -66,7 +66,11 @@ public class EndlessJabberWakefulService extends IntentService {
                         break;
                     }
                 }
-            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+            } catch (InstantiationException e) {
+                |
+            } catch (IllegalAccessException e) {
+                |
+            } catch (ClassNotFoundException e) {
 
             }
         }

--- a/QKSMS/src/main/java/com/mariussoft/endlessjabber/sdk/EndlessJabberWakefulService.java
+++ b/QKSMS/src/main/java/com/mariussoft/endlessjabber/sdk/EndlessJabberWakefulService.java
@@ -16,12 +16,12 @@ public class EndlessJabberWakefulService extends IntentService {
         Context context = getApplicationContext();
 
         // Get the class to call
-        String implemenationClass = context.getSharedPreferences("EndlessJabberSDK", Context.MODE_PRIVATE).getString("InterfaceClass", null);
+        String implementationClass = context.getSharedPreferences("EndlessJabberSDK", Context.MODE_PRIVATE).getString("InterfaceClass", null);
 
-        if (implemenationClass != null) {
+        if (implementationClass != null) {
             IEndlessJabberImplementation instanceOfMyClass;
             try {
-                instanceOfMyClass = (IEndlessJabberImplementation) Class.forName(implemenationClass).newInstance();
+                instanceOfMyClass = (IEndlessJabberImplementation) Class.forName(implementationClass).newInstance();
 
                 Bundle extras = intent.getExtras();
 
@@ -67,9 +67,9 @@ public class EndlessJabberWakefulService extends IntentService {
                     }
                 }
             } catch (InstantiationException e) {
-                |
+
             } catch (IllegalAccessException e) {
-                |
+
             } catch (ClassNotFoundException e) {
 
             }

--- a/QKSMS/src/main/java/com/mariussoft/endlessjabber/sdk/EndlessJabberWakefulService.java
+++ b/QKSMS/src/main/java/com/mariussoft/endlessjabber/sdk/EndlessJabberWakefulService.java
@@ -7,72 +7,69 @@ import android.os.Bundle;
 
 public class EndlessJabberWakefulService extends IntentService {
 
-	public EndlessJabberWakefulService() {
-		super("EndlessJabberWakefulService");
-	}
+    public EndlessJabberWakefulService() {
+        super("EndlessJabberWakefulService");
+    }
 
-	@Override
-	protected void onHandleIntent(Intent intent) {
-		Context context = getApplicationContext();
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        Context context = getApplicationContext();
 
-		// Get the class to call
-		String implemenationClass = context.getSharedPreferences("EndlessJabberSDK", Context.MODE_PRIVATE).getString("InterfaceClass", null);
+        // Get the class to call
+        String implemenationClass = context.getSharedPreferences("EndlessJabberSDK", Context.MODE_PRIVATE).getString("InterfaceClass", null);
 
-		if (implemenationClass == null) {
-			return;
-		}
+        if (implemenationClass != null) {
+            IEndlessJabberImplementation instanceOfMyClass;
+            try {
+                instanceOfMyClass = (IEndlessJabberImplementation) Class.forName(implemenationClass).newInstance();
 
-		IEndlessJabberImplementation instanceOfMyClass;
-		try {
-			instanceOfMyClass = (IEndlessJabberImplementation) Class.forName(implemenationClass).newInstance();
+                Bundle extras = intent.getExtras();
 
-			Bundle extras = intent.getExtras();
+                switch (extras.getString("Action")) {
+                    case "UpdateRead": {
+                        long time = extras.getLong("Time");
+                        int conversationID = extras.getInt("ConversationID");
+                        instanceOfMyClass.UpdateReadMessages(context, time, conversationID);
+                        break;
+                    }
+                    case "DeleteThread": {
 
-			switch (extras.getString("Action")) {
-			case "UpdateRead": {
-				long time = extras.getLong("Time");
-				int conversationID = extras.getInt("ConversationID");
-				instanceOfMyClass.UpdateReadMessages(context, time, conversationID);
-				break;
-			}
-			case "DeleteThread": {
+                        int conversationID = extras.getInt("ConversationID");
+                        instanceOfMyClass.DeleteThread(context, conversationID);
+                        break;
+                    }
+                    case "SendMMS": {
 
-				int conversationID = extras.getInt("ConversationID");
-				instanceOfMyClass.DeleteThread(context, conversationID);
-				break;
-			}
-			case "SendMMS": {
+                        boolean save = extras.getBoolean("Save");
+                        boolean send = extras.getBoolean("Send");
+                        String[] Recipients = extras.getStringArray("Recipients");
 
-				boolean save = extras.getBoolean("Save");
-				boolean send = extras.getBoolean("Send");
-				String[] Recipients = extras.getStringArray("Recipients");
+                        MMSPart[] parts = new MMSPart[extras.getParcelableArray("Parts").length];
 
-				MMSPart[] parts = new MMSPart[extras.getParcelableArray("Parts").length];
+                        for (int i = 0; i < parts.length; i++) {
+                            parts[i] = (MMSPart) extras.getParcelableArray("Parts")[i];
+                        }
 
-				for (int i = 0; i < parts.length; i++) {
-					parts[i] = (MMSPart) extras.getParcelableArray("Parts")[i];
-				}
+                        instanceOfMyClass.SendMMS(context, Recipients, parts, extras.getString("Subject"), save, send);
+                        break;
+                    }
+                    case "SendSMS": {
+                        boolean send = extras.getBoolean("Send");
+                        String[] Recipients = extras.getStringArray("Recipients");
+                        String message = extras.getString("Message");
 
-				instanceOfMyClass.SendMMS(context, Recipients, parts, extras.getString("Subject"), save, send);
-				break;
-			}
-			case "SendSMS": {
-				boolean send = extras.getBoolean("Send");
-				String[] Recipients = extras.getStringArray("Recipients");
-				String message = extras.getString("Message");
+                        instanceOfMyClass.SendSMS(context, Recipients, message, send);
+                        break;
+                    }
+                    case "UpdateInfo": {
+                        EndlessJabberInterface.SendInfoToEndlessJabber(context);
+                        break;
+                    }
+                }
+            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
 
-				instanceOfMyClass.SendSMS(context, Recipients, message, send);
-				break;
-			}
-			case "UpdateInfo": {
-				EndlessJabberInterface.SendInfoToEndlessJabber(context);
-				break;
-			}
-			}
-		} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-
-		}
-
-		EndlessJabberReceiver.completeWakefulIntent(intent);
-	}
+            }
+        }
+        EndlessJabberReceiver.completeWakefulIntent(intent);
+    }
 }


### PR DESCRIPTION
The EndlessJabber wakeful service can in some cases hold a wakelock. I don't have enough insight into this project to say if/when the `implementationClass` is null but I suspect 'not very often' is the answer and that this isn't a major source of battery drain etc so I don't think it will affect https://github.com/qklabs/qksms/issues/198 a great deal. 

It might be nice to track a metric here to see how often `implementationClass == null` happens so we can quantify what difference this makes. 

This code was taken from somewhere else, I'd like to make a PR to the original source if possible too. I think that's [this repo](https://github.com/celeronpm/YappySDK), could someone confirm that for me?

What was the rational behind copying in the source code here? (cc @mvdan). A few lint fixes have been made to the code but nothing meaningful that I can see. Having a jar that can be updated if there are patches seems more useful to me. Maybe not a huge issue here, but there are [some places](https://github.com/qklabs/qksms/blob/master/QKSMS/src/main/java/com/android/mms/transaction/TransactionService.java) that missing a patch could be quite bad. Worth having a separate conversation about this? I can open an issue/take it to slack if anyone's interested