### PR TITLE
Fix issue #269

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/common/utils/ImageUtils.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/utils/ImageUtils.java
@@ -113,6 +113,9 @@ public class ImageUtils {
         Cursor cursor = context.getContentResolver().query(
                 photoUri, new String[]{MediaStore.Images.ImageColumns.ORIENTATION}, null, null, null
         );
+        if (cursor == null) {
+            return 0;
+        }
         if (cursor.moveToFirst()) {
             result = cursor.getInt(0);
         } else {


### PR DESCRIPTION
Reference: https://github.com/qklabs/qksms/issues/269 

This just checks if the cursor is usable and if not returns 0, since it wasn't it'd throw an exception that was catche'd on the activity then it'd say it couldn't add the picture.