### PR TITLE
squid:S1068 - Unused private fields should be removed

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/receiver/DeliveredReceiver.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/receiver/DeliveredReceiver.java
@@ -10,7 +10,6 @@ import com.moez.QKSMS.R;
 import com.moez.QKSMS.ui.settings.SettingsFragment;
 
 public class DeliveredReceiver extends com.moez.QKSMS.mmssms.DeliveredReceiver {
-    private final String TAG = "DeliveredReceiver";
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/QKSMS/src/main/java/com/moez/QKSMS/receiver/MessageFailedReceiver.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/receiver/MessageFailedReceiver.java
@@ -9,7 +9,6 @@ import com.moez.QKSMS.R;
 import com.moez.QKSMS.transaction.NotificationManager;
 
 public class MessageFailedReceiver extends BroadcastReceiver {
-    private final String TAG = "MessageFailedReceiver";
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/QKSMS/src/main/java/com/moez/QKSMS/receiver/MmsReceiver.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/receiver/MmsReceiver.java
@@ -8,7 +8,6 @@ import android.net.ConnectivityManager;
 import com.android.mms.transaction.TransactionSettings;
 
 public class MmsReceiver extends BroadcastReceiver {
-    private final String TAG = "MmsReceiver";
 
     private ConnectivityManager connectivityManager;
     private TransactionSettings transactionSettings;

--- a/QKSMS/src/main/java/com/moez/QKSMS/receiver/PushReceiver.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/receiver/PushReceiver.java
@@ -41,7 +41,6 @@ import static com.google.android.mms.pdu_alt.PduHeaders.MESSAGE_TYPE_READ_ORIG_I
  */
 public class PushReceiver extends BroadcastReceiver {
     private static final String TAG = "PushReceiver";
-    private static final boolean DEBUG = false;
     private static final boolean LOCAL_LOGV = false;
 
     private class ReceivePushTask extends AsyncTask<Intent,Void,Void> {

--- a/QKSMS/src/main/java/com/moez/QKSMS/receiver/WearableIntentReceiver.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/receiver/WearableIntentReceiver.java
@@ -34,7 +34,6 @@ import static android.support.v4.app.NotificationCompat.BigTextStyle;
 import static android.support.v4.app.NotificationCompat.WearableExtender;
 
 public class WearableIntentReceiver extends BroadcastReceiver {
-    private static final String TAG = "WearableIntentActivity";
 
     public static final String ACTION_REPLY = "com.moez.QKSMS.receiver.WearableIntentReceiver.REPLY";
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1068 - Unused private fields should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1068
Please let me know if you have any questions.
George Kankava