### PR TITLE
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/common/google/BlobCache.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/google/BlobCache.java
@@ -400,9 +400,33 @@ public class BlobCache implements Closeable {
     }
 
     public static class LookupRequest {
-        public long key;        // input: the key to find
-        public byte[] buffer;   // input/output: the buffer to store the blob
-        public int length;      // output: the length of the blob
+        private long key;        // input: the key to find
+        private byte[] buffer;   // input/output: the buffer to store the blob
+        private int length;      // output: the length of the blob
+
+        public long getKey() {
+            return key;
+        }
+
+        public void setKey(long key) {
+            this.key = key;
+        }
+
+        public byte[] getBuffer() {
+            return buffer;
+        }
+
+        public void setBuffer(byte[] buffer) {
+            this.buffer = buffer;
+        }
+
+        public int getLength() {
+            return length;
+        }
+
+        public void setLength(int length) {
+            this.length = length;
+        }
     }
 
     // This method is for one-off lookup. For repeated lookup, use the version

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/google/ImageCacheService.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/google/ImageCacheService.java
@@ -50,8 +50,24 @@ public class ImageCacheService {
             mData = data;
             mOffset = offset;
         }
-        public byte[] mData;
-        public int mOffset;
+        private byte[] mData;
+        private int mOffset;
+
+        public byte[] getData() {
+            return mData;
+        }
+
+        public void setData(byte[] mData) {
+            this.mData = mData;
+        }
+
+        public int getOffset() {
+            return mOffset;
+        }
+
+        public void setOffset(int mOffset) {
+            this.mOffset = mOffset;
+        }
     }
 
     public ImageData getImageData(String path, int type) {

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/google/ThumbnailManager.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/google/ThumbnailManager.java
@@ -322,8 +322,8 @@ public class ThumbnailManager extends BackgroundLoaderManager {
             if (data != null) {
                 Options options = new Options();
                 options.inPreferredConfig = Config.ARGB_8888;
-                Bitmap bitmap = requestDecode(data.mData,
-                        data.mOffset, data.mData.length - data.mOffset, options);
+                Bitmap bitmap = requestDecode(data.getData(),
+                        data.getOffset(), data.getData().length - data.getOffset(), options);
                 if (bitmap == null) {
                     Log.w(TAG, "decode cached failed " + path);
                 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
Please let me know if you have any questions.
George Kankava