### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/common/google/PduLoaderManager.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/google/PduLoaderManager.java
@@ -87,11 +87,11 @@ public class PduLoaderManager extends BackgroundLoaderManager {
         final SlideshowModel slideshow = (requestSlideshow && !DEBUG_DISABLE_CACHE) ?
                 mSlideshowCache.get(uri) : null;
 
-        final boolean slideshowExists = (!requestSlideshow || slideshow != null);
-        final boolean pduExists = (cacheEntry != null && cacheEntry.getPdu() != null);
+        final boolean slideshowExists = !requestSlideshow || slideshow != null;
+        final boolean pduExists = cacheEntry != null && cacheEntry.getPdu() != null;
         final boolean taskExists = mPendingTaskUris.contains(uri);
         final boolean newTaskRequired = (!pduExists || !slideshowExists) && !taskExists;
-        final boolean callbackRequired = (callback != null);
+        final boolean callbackRequired = callback != null;
 
         if (pduExists && slideshowExists) {
             if (callbackRequired) {

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/google/ThumbnailManager.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/google/ThumbnailManager.java
@@ -122,10 +122,10 @@ public class ThumbnailManager extends BackgroundLoaderManager {
 
         final Bitmap thumbnail = DEBUG_DISABLE_CACHE ? null : mThumbnailCache.get(uri);
 
-        final boolean thumbnailExists = (thumbnail != null);
+        final boolean thumbnailExists = thumbnail != null;
         final boolean taskExists = mPendingTaskUris.contains(uri);
         final boolean newTaskRequired = !thumbnailExists && !taskExists;
-        final boolean callbackRequired = (callback != null);
+        final boolean callbackRequired = callback != null;
 
         if (Log.isLoggable(LogTag.THUMBNAIL_CACHE, Log.DEBUG)) {
             Log.v(TAG, "getThumbnail mThumbnailCache.get for uri: " + uri + " thumbnail: " +


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava